### PR TITLE
Timer light off with retry

### DIFF
--- a/blueprints/automations/timer-light-off-with-retry/README.md
+++ b/blueprints/automations/timer-light-off-with-retry/README.md
@@ -1,0 +1,11 @@
+# Timer light off with retry
+
+This blueprint creates an automation that switches a light off when a
+countdown timer finishes. Useful for controlling lights with the strategy
+described in [this video](https://youtu.be/SuLPMxQUv0Q). You need to
+create one [timer](https://www.home-assistant.io/integrations/timer/) for
+each light. The blueprint is parameterized by the light and the timer.
+
+Note: this blueprint only handles switching off the light. A separate
+automation is needed to start the countdown timer when the light is
+switched on.

--- a/blueprints/automations/timer-light-off-with-retry/timer-light-off-with-retry.yaml
+++ b/blueprints/automations/timer-light-off-with-retry/timer-light-off-with-retry.yaml
@@ -1,0 +1,53 @@
+blueprint:
+  name: Timer light off with retry
+  description: Turn light off when timer finishes. Retry if light-off command fails.
+  author: Kevin Backhouse
+  domain: automation
+  input:
+    timer_arg:
+      name: Timer
+      description: The timer associated with the light
+      selector:
+        entity:
+          filter:
+            - domain: timer
+    light_arg:
+      name: Light
+      description: The light to switch off
+      selector:
+        entity:
+          filter:
+            - domain: light
+triggers:
+  - trigger: event
+    event_type: timer.finished
+    event_data:
+      entity_id: !input timer_arg
+conditions: []
+actions:
+  - action: light.turn_off
+    continue_on_error: true
+    metadata: {}
+    data: {}
+    target:
+      entity_id: !input light_arg
+  - delay:
+      hours: 0
+      minutes: 0
+      seconds: 1
+      milliseconds: 0
+  - if:
+      - condition: state
+        entity_id: !input light_arg
+        state: "on"
+      - condition: state
+        entity_id: !input timer_arg
+        state: idle
+    then:
+      - action: timer.start
+        metadata: {}
+        data:
+          duration: "4"
+        target:
+          entity_id: !input timer_arg
+mode: queued


### PR DESCRIPTION
Blueprint that turns a light off when a countdown timer finishes. Useful for controlling lights with the strategy described in [this video](https://youtu.be/SuLPMxQUv0Q). You need to create one [timer](https://www.home-assistant.io/integrations/timer/) for each light. The blueprint is parameterized by the light and the timer. Note: this blueprint only handles switching off the light. A separate automation is needed to start the countdown timer when the light is switched on.