### PR TITLE
Invert logic for better reliability

### DIFF
--- a/blueprints/automations/timer-light-off-with-retry/timer-light-off-with-retry.yaml
+++ b/blueprints/automations/timer-light-off-with-retry/timer-light-off-with-retry.yaml
@@ -37,9 +37,11 @@ actions:
       seconds: 1
       milliseconds: 0
   - if:
-      - condition: state
-        entity_id: !input light_arg
-        state: "on"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: !input light_arg
+            state: "off"
       - condition: state
         entity_id: !input timer_arg
         state: idle

--- a/blueprints/scripts/timer-light-on-with-retry/timer-light-on-with-retry.yaml
+++ b/blueprints/scripts/timer-light-on-with-retry/timer-light-on-with-retry.yaml
@@ -61,6 +61,7 @@ sequence:
       - repeat:
           sequence:
             - action: light.turn_on
+              continue_on_error: true
               metadata: {}
               data: {}
               target:
@@ -71,9 +72,11 @@ sequence:
                 seconds: 1
                 milliseconds: 0
           while:
-            - condition: state
-              entity_id: !input light_arg
-              state: "off"
+            - condition: not
+              conditions:
+                - condition: state
+                  entity_id: !input light_arg
+                  state: "on"
             - condition: state
               entity_id: !input timer_arg
               state: active


### PR DESCRIPTION
If `light.turn_on` or `light.turn_off` fails then the light often gets a state like "Unknown". So it's more reliable to keep looping until the light is in the desired state.